### PR TITLE
remove NativeModule

### DIFF
--- a/src/AndroidTelephonyModule.ts
+++ b/src/AndroidTelephonyModule.ts
@@ -1,5 +1,5 @@
-import { NativeModule, requireNativeModule } from "expo";
-declare class AndroidTelephonyModule extends NativeModule {
+import { requireNativeModule } from "expo";
+declare class AndroidTelephonyModule {
   getAllCellInfo(): string;
   execute(action: string): string;
 }


### PR DESCRIPTION
# Description

Fixed missing NativeModule issue in older Expo versions (~51.0.37)